### PR TITLE
Add image loader and procedural map

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ maple‑trail/
 ├─ eventEngine.js      # random event deck (Sprint #2)
 ├─ modal.js            # modal overlay
 ├─ ui.js               # HUD controls & effects
+├─ loader.js           # sprite manifest & loader
 └─ assets/             # art & audio (added in later sprints)
 Development Workflow
 Sprint	Focus	Status
 #1	Canvas, HUD, wagon movement	✅ Completed
-#2	Random event system + modal	⏳ In progress
-#3	Procedural map generator	🚧 Planned
+#2	Random event system + modal	✅ Completed
+#3	Procedural map generator	⏳ In progress
 #4	Vehicle breakdown & inventory	🚧 Planned
 #5	Border paperwork mini‑game	🚧 Planned
 #6	U.S. “upgrade burst” scene	🚧 Planned

--- a/maple-to-manhattan/loader.js
+++ b/maple-to-manhattan/loader.js
@@ -1,0 +1,19 @@
+export const manifest = {
+  wagon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAklEQVR4AewaftIAAAApSURBVKXBAQEAAAiDMKR/5xuC7WAjkEgiiSSSSCKJJJJIIokkkkgiiR5WbwIeFJRVdgAAAABJRU5ErkJggg==',
+  node: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAklEQVR4AewaftIAAAAqSURBVKXBAQEAMAyDMI7yOt9FkLxtRyCRRBJJJJFEEkkkkUQSSSSRRBJ9YpoCn/BE/O4AAAAASUVORK5CYII=',
+};
+
+export const images = {};
+
+export function loadImages() {
+  const promises = [];
+  for (const [key, url] of Object.entries(manifest)) {
+    const img = new Image();
+    images[key] = img;
+    promises.push(new Promise(resolve => {
+      img.onload = resolve;
+      img.src = url;
+    }));
+  }
+  return Promise.all(promises);
+}

--- a/maple-to-manhattan/map.js
+++ b/maple-to-manhattan/map.js
@@ -1,18 +1,32 @@
 import { gameState } from './state.js';
 import { updateHUD } from './ui.js';
 
-export function generateMap() {
-  return [
-    { id: 'QC', x: 80, y: 300, label: 'Frozen Québec' },
-    { id: 'MTL', x: 250, y: 250, label: 'Snow-choked Montréal' },
-    { id: 'BRD', x: 420, y: 220, label: 'Icy Border Post' },
-    { id: 'NY', x: 590, y: 260, label: 'Miraculous Upstate NY' },
-    { id: 'CT', x: 760, y: 310, label: 'Greenwich Utopia' },
-  ];
+function mulberry32(a) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
 }
 
-export function travelTo(targetIndex) {
-  const nodes = generateMap();
+export function generateMap(seed = 1) {
+  const rand = mulberry32(seed);
+  const count = 7 + Math.floor(rand() * 4); // 7-10 nodes
+  const nodes = [];
+  const width = 800;
+  const height = 400;
+  for (let i = 0; i < count; i++) {
+    const t = i / (count - 1);
+    const x = 80 + t * (width - 160);
+    const y =
+      height / 2 + Math.sin(t * Math.PI) * 80 + (rand() * 30 - 15);
+    nodes.push({ id: `N${i}`, x, y, label: `Waypoint ${i + 1}` });
+  }
+  return nodes;
+}
+
+export function travelTo(nodes, targetIndex, wagonPos) {
   const start = nodes[gameState.nodeIndex];
   const target = nodes[targetIndex];
   if (!target) return;
@@ -23,31 +37,17 @@ export function travelTo(targetIndex) {
   function animate() {
     progress++;
     const t = Math.min(progress / duration, 1);
-    const canvas = document.getElementById('gameCanvas');
-    const ctx = canvas.getContext('2d');
-    const x = start.x + (target.x - start.x) * t;
-    const y = start.y + (target.y - start.y) * t;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    nodes.forEach(n => {
-      ctx.fillStyle = '#888';
-      ctx.beginPath();
-      ctx.arc(n.x, n.y, 10, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.fillStyle = '#fff';
-      ctx.fillText(n.label, n.x - 20, n.y - 15);
-    });
-    ctx.fillStyle = 'blue';
-    ctx.fillRect(x - 5, y - 5, 10, 10); // TODO: Replace with real art
+    wagonPos.x = start.x + (target.x - start.x) * t;
+    wagonPos.y = start.y + (target.y - start.y) * t;
 
     if (t < 1) {
       requestAnimationFrame(animate);
     } else {
       gameState.nodeIndex = targetIndex;
-      console.log('Arrived at', target.label); // TODO: Add random events
       updateHUD();
     }
   }
 
-  animate();
+  requestAnimationFrame(animate);
 }
 

--- a/maple-to-manhattan/state.js
+++ b/maple-to-manhattan/state.js
@@ -1,5 +1,6 @@
 export const gameState = {
   nodeIndex: 0,
+  seed: 1,
   stats: {
     health: 75,
     morale: 75,


### PR DESCRIPTION
## Summary
- load sprites with a small manifest
- draw the path and wagon from loaded images
- generate a seeded curved map with 7–10 nodes
- track RNG seed in game state
- update README for Sprint status and new loader module

## Testing
- `node --check maple-to-manhattan/main.js`
- `node --check maple-to-manhattan/map.js`
- `node --check maple-to-manhattan/state.js`
- `node --check maple-to-manhattan/loader.js`

------
https://chatgpt.com/codex/tasks/task_e_68825f9008948320bf65cc64ef1becc2