### PR TITLE
Implement inventory and breakdown events

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Development Workflow
 Sprint	Focus	Status
 #1	Canvas, HUD, wagon movement	✅ Completed
 #2	Random event system + modal	✅ Completed
-#3	Procedural map generator	⏳ In progress
-#4	Vehicle breakdown & inventory	🚧 Planned
+#3      Procedural map generator        ✅ Completed
+#4      Vehicle breakdown & inventory   ⏳ In progress
 #5	Border paperwork mini‑game	🚧 Planned
 #6	U.S. “upgrade burst” scene	🚧 Planned
 #7	Greenwich finale & credits	🚧 Planned

--- a/maple-to-manhattan/eventEngine.js
+++ b/maple-to-manhattan/eventEngine.js
@@ -54,6 +54,36 @@ const baseEvents = [
       { stat: 'cash', delta: 20 },
     ],
   },
+  {
+    id: 'GAS_STATION_CACHE',
+    title: 'Abandoned Gas Station',
+    description: 'You find a dusty box of spare parts.',
+    effects: [
+      { inventory: 'parts', delta: 1 },
+    ],
+  },
+  {
+    id: 'FLAT_TIRE',
+    title: 'Flat Tire',
+    description: 'A sharp rock blows out a tire.',
+    choices: [
+      {
+        text: 'Use spare part to repair',
+        requires: { inventory: 'parts', count: 1 },
+        effects: [
+          { inventory: 'parts', delta: -1 },
+          { stat: 'morale', delta: 3 },
+        ],
+      },
+      {
+        text: 'Drive on the rim',
+        effects: [
+          { stat: 'health', delta: -10 },
+          { stat: 'fuel', delta: -5 },
+        ],
+      },
+    ],
+  },
 ];
 
 function shuffle(arr) {

--- a/maple-to-manhattan/index.html
+++ b/maple-to-manhattan/index.html
@@ -14,6 +14,11 @@
         <div class="stat" id="warmth">Warmth: <div class="bar"><span></span></div></div>
         <div class="stat" id="fuel">Fuel: <div class="bar"><span></span></div></div>
         <div class="stat" id="cashLabel">Cash: $0</div>
+        <div id="inventory">
+            <div class="inv-item">🔩 <span id="partsCount">0</span></div>
+            <div class="inv-item">🧰 <span id="toolsCount">0</span></div>
+            <div class="inv-item">🎒 <span id="gearCount">0</span></div>
+        </div>
         <button id="travelBtn">Travel</button>
         <button id="campBtn">Camp</button>
     </div>

--- a/maple-to-manhattan/main.js
+++ b/maple-to-manhattan/main.js
@@ -1,4 +1,4 @@
-import { gameState, modifyStat } from './state.js';
+import { gameState, modifyStat, modifyInventory } from './state.js';
 import { generateMap, travelTo } from './map.js';
 import { updateHUD } from './ui.js';
 import { initEvents, drawRandomEvent } from './eventEngine.js';
@@ -9,7 +9,10 @@ let ctx, nodes;
 let wagonPos = { x: 0, y: 0 };
 
 function applyEffects(effects) {
-    effects.forEach(e => modifyStat(e.stat, e.delta));
+    effects.forEach(e => {
+        if (e.stat) modifyStat(e.stat, e.delta);
+        if (e.inventory) modifyInventory(e.inventory, e.delta);
+    });
     updateHUD();
 }
 
@@ -54,10 +57,17 @@ window.addEventListener('load', async () => {
 
     function triggerEvent() {
         const ev = drawRandomEvent();
-        applyEffects(ev.effects);
-        showModal(ev);
         travelBtn.disabled = true;
         campBtn.disabled = true;
+
+        if (ev.choices) {
+            showModal(ev, choice => {
+                applyEffects(choice.effects);
+            });
+        } else {
+            applyEffects(ev.effects);
+            showModal(ev);
+        }
     }
 
     const travelBtn = document.getElementById('travelBtn');

--- a/maple-to-manhattan/state.js
+++ b/maple-to-manhattan/state.js
@@ -8,6 +8,11 @@ export const gameState = {
     fuel: 75,
     cash: 75,
   },
+  inventory: {
+    parts: 0,
+    tools: 0,
+    gear: 0,
+  },
 };
 
 export function clampStat(key) {
@@ -20,5 +25,19 @@ export function modifyStat(key, delta) {
     clampStat(key);
     window.dispatchEvent(new CustomEvent('statChanged', { detail: { key } }));
   }
+}
+
+export function modifyInventory(item, delta) {
+  if (gameState.inventory.hasOwnProperty(item)) {
+    gameState.inventory[item] = Math.max(0, gameState.inventory[item] + delta);
+    window.dispatchEvent(
+      new CustomEvent('inventoryChanged', { detail: { item } })
+    );
+  }
+}
+
+// expose state for modal requirement checks
+if (typeof window !== 'undefined') {
+  window.gameState = gameState;
 }
 

--- a/maple-to-manhattan/style.css
+++ b/maple-to-manhattan/style.css
@@ -36,6 +36,17 @@ body {
     background: #3fa9f5;
     width: 50%;
 }
+
+#inventory {
+    display: flex;
+    gap: 6px;
+}
+
+.inv-item {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
 button {
     padding: 4px 10px;
     background: #3fa9f5;
@@ -67,6 +78,13 @@ button:hover {
     border: 4px solid #3fa9f5;
     padding: 10px;
     color: #fff;
+}
+
+.choices {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
 }
 
 .bar span.flash {

--- a/maple-to-manhattan/ui.js
+++ b/maple-to-manhattan/ui.js
@@ -7,11 +7,24 @@ export function updateHUD() {
   });
   const label = document.getElementById('cashLabel');
   if (label) label.textContent = `Cash: $${gameState.stats.cash}`;
+
+  ['parts', 'tools', 'gear'].forEach(item => {
+    const span = document.getElementById(`${item}Count`);
+    if (span) span.textContent = gameState.inventory[item];
+  });
 }
 
 window.addEventListener('statChanged', e => {
   const stat = e.detail.key;
   const span = document.querySelector(`#${stat} .bar span`);
+  if (!span) return;
+  span.classList.add('flash');
+  setTimeout(() => span.classList.remove('flash'), 300);
+});
+
+window.addEventListener('inventoryChanged', e => {
+  const item = e.detail.item;
+  const span = document.getElementById(`${item}Count`);
   if (!span) return;
   span.classList.add('flash');
   setTimeout(() => span.classList.remove('flash'), 300);


### PR DESCRIPTION
## Summary
- add inventory object and modify state helpers
- display inventory counts on HUD
- enable item-based choice options in modal events
- support car breakdown events and loot events
- update README workflow status for Sprint 3 & 4

## Testing
- `node --check maple-to-manhattan/modal.js`
- `node --check maple-to-manhattan/main.js`
- `node --check maple-to-manhattan/eventEngine.js`
- `node --check maple-to-manhattan/state.js`

------
https://chatgpt.com/codex/tasks/task_e_688261aa0b588320a1c3934e47a3d1d2