### PR TITLE
Add border paperwork mini-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Sprint	Focus	Status
 #1	Canvas, HUD, wagon movement	✅ Completed
 #2	Random event system + modal	✅ Completed
 #3      Procedural map generator        ✅ Completed
-#4      Vehicle breakdown & inventory   ⏳ In progress
-#5	Border paperwork mini‑game	🚧 Planned
+#4      Vehicle breakdown & inventory   ✅ Completed
+#5	Border paperwork mini‑game	⏳ In progress
 #6	U.S. “upgrade burst” scene	🚧 Planned
 #7	Greenwich finale & credits	🚧 Planned
 #8	Save / load (localStorage)	🚧 Planned

--- a/maple-to-manhattan/assets/manifest.js
+++ b/maple-to-manhattan/assets/manifest.js
@@ -1,0 +1,4 @@
+export const sprites = {
+  form_duplicate_carbon:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAQAAAD+Th5XAAAALElEQVR42mP8//8/AzWAiST9T4bRhIQYBBxiBmNZgYjWQBjAo0L8TANkT0kAEAkDD28LdK0sAAAAASUVORK5CYII=',
+};

--- a/maple-to-manhattan/borderMinigame.js
+++ b/maple-to-manhattan/borderMinigame.js
@@ -1,0 +1,83 @@
+import { gameState } from './state.js';
+import { useItem } from './inventory.js';
+
+export function startMiniGame() {
+  const overlay = document.createElement('div');
+  overlay.id = 'borderMini';
+  Object.assign(overlay.style, {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(0,0,0,0.8)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 100,
+    color: '#fff',
+    fontFamily: 'sans-serif',
+  });
+
+  let time = 60;
+  const timer = document.createElement('div');
+  timer.textContent = `Time: ${time}`;
+  overlay.appendChild(timer);
+
+  const form = document.createElement('div');
+  overlay.appendChild(form);
+  const labels = ['Name', 'Purpose', 'Maple-Syrup Decl.', 'Vehicle ID', 'Passport #'];
+  const inputs = labels.map(l => {
+    const input = document.createElement('input');
+    input.placeholder = l;
+    form.appendChild(input);
+    form.appendChild(document.createElement('br'));
+    return input;
+  });
+
+  const ok = document.createElement('button');
+  ok.textContent = 'OK';
+  overlay.appendChild(ok);
+
+  if (gameState.inventory.form_duplicate_carbon > 0) {
+    const fast = document.createElement('button');
+    fast.textContent = 'Fast-Track';
+    overlay.appendChild(fast);
+    fast.addEventListener('click', () => {
+      if (useItem('form_duplicate_carbon')) success();
+    });
+  }
+
+  const interval = setInterval(() => {
+    time--;
+    timer.textContent = `Time: ${time}`;
+    if (time <= 0) fail();
+  }, 1000);
+
+  function cleanup() {
+    clearInterval(interval);
+    window.removeEventListener('keydown', escListener);
+    overlay.remove();
+  }
+
+  function success() {
+    cleanup();
+    window.dispatchEvent(new Event('borderSuccess'));
+  }
+
+  function fail() {
+    cleanup();
+    window.dispatchEvent(new Event('borderFail'));
+  }
+
+  function escListener(e) {
+    if (e.key === 'Escape') fail();
+  }
+
+  window.addEventListener('keydown', escListener);
+
+  ok.addEventListener('click', () => {
+    const filled = inputs.every(i => i.value.trim());
+    if (filled) success();
+  });
+
+  document.body.appendChild(overlay);
+}

--- a/maple-to-manhattan/inventory.js
+++ b/maple-to-manhattan/inventory.js
@@ -1,0 +1,13 @@
+import { gameState, modifyInventory } from './state.js';
+
+export function useItem(item) {
+  if (gameState.inventory[item] > 0) {
+    modifyInventory(item, -1);
+    return true;
+  }
+  return false;
+}
+
+if (typeof window !== 'undefined') {
+  window.useItem = useItem;
+}

--- a/maple-to-manhattan/main.js
+++ b/maple-to-manhattan/main.js
@@ -70,6 +70,18 @@ window.addEventListener('load', async () => {
         }
     }
 
+    function handleArrival(idx) {
+        travelTo(nodes, idx, wagonPos);
+        const target = nodes[idx];
+        if (target && target.id === 'BRD') {
+            travelBtn.disabled = true;
+            campBtn.disabled = true;
+            import('./borderMinigame.js').then(m => m.startMiniGame());
+        } else {
+            triggerEvent();
+        }
+    }
+
     const travelBtn = document.getElementById('travelBtn');
     const campBtn = document.getElementById('campBtn');
 
@@ -79,8 +91,7 @@ window.addEventListener('load', async () => {
         const y = evt.clientY - rect.top;
         const clicked = nodes.findIndex(n => Math.hypot(n.x - x, n.y - y) < 10);
         if (clicked >= 0) {
-            travelTo(nodes, clicked, wagonPos);
-            triggerEvent();
+            handleArrival(clicked);
         }
     });
 
@@ -88,8 +99,7 @@ window.addEventListener('load', async () => {
         modifyStat('fuel', -5);
         modifyStat('warmth', -3);
         const next = Math.min(gameState.nodeIndex + 1, nodes.length - 1);
-        travelTo(nodes, next, wagonPos);
-        triggerEvent();
+        handleArrival(next);
     });
 
     campBtn.addEventListener('click', () => {
@@ -100,6 +110,19 @@ window.addEventListener('load', async () => {
     });
 
     window.addEventListener('modalClosed', () => {
+        travelBtn.disabled = false;
+        campBtn.disabled = false;
+    });
+
+    window.addEventListener('borderSuccess', () => {
+        modifyStat('morale', 10);
+        travelBtn.disabled = false;
+        campBtn.disabled = false;
+    });
+
+    window.addEventListener('borderFail', () => {
+        modifyStat('cash', -20);
+        modifyStat('morale', -5);
         travelBtn.disabled = false;
         campBtn.disabled = false;
     });

--- a/maple-to-manhattan/state.js
+++ b/maple-to-manhattan/state.js
@@ -12,6 +12,7 @@ export const gameState = {
     parts: 0,
     tools: 0,
     gear: 0,
+    form_duplicate_carbon: 1,
   },
 };
 

--- a/maple-to-manhattan/ui.js
+++ b/maple-to-manhattan/ui.js
@@ -1,4 +1,5 @@
 import { gameState } from './state.js';
+import { sprites } from './assets/manifest.js';
 
 export function updateHUD() {
   ['health', 'morale', 'warmth', 'fuel'].forEach(stat => {
@@ -8,8 +9,24 @@ export function updateHUD() {
   const label = document.getElementById('cashLabel');
   if (label) label.textContent = `Cash: $${gameState.stats.cash}`;
 
-  ['parts', 'tools', 'gear'].forEach(item => {
-    const span = document.getElementById(`${item}Count`);
+  const invDiv = document.getElementById('inventory');
+  Object.keys(gameState.inventory).forEach(item => {
+    let span = document.getElementById(`${item}Count`);
+    if (!span && invDiv) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'inv-item';
+      if (sprites[item]) {
+        const img = document.createElement('img');
+        img.src = sprites[item];
+        img.width = 16;
+        img.height = 16;
+        wrapper.appendChild(img);
+      }
+      span = document.createElement('span');
+      span.id = `${item}Count`;
+      wrapper.appendChild(span);
+      invDiv.appendChild(wrapper);
+    }
     if (span) span.textContent = gameState.inventory[item];
   });
 }


### PR DESCRIPTION
## Summary
- mark sprint 4 complete and start sprint 5
- add simple item usage helper and starting inventory item
- implement border paperwork mini-game overlay
- trigger mini-game when reaching node `BRD` and handle results
- show inventory icons dynamically from asset manifest
- include sprite placeholder for form duplicate carbon

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882653852c88320b4413f74d7ff5748