### PR TITLE
Add humorous Canadian random events

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The project is intentionally zero‑dependency: pure HTML + CSS + vanill
 Gameplay Features
 Resource Management – Juggle Health, Morale, Warmth, Fuel, Cash; every choice matters when the heater core explodes on a dirt road.
 
-Random Event Deck – Blizzard white‑outs, cassette‑tape morale boosts, border‑agent shenanigans… no two runs are identical.
+Random Event Deck – Blizzard white‑outs, cassette‑tape morale boosts, border‑agent shenanigans, and new Canadian antics like maple syrup heists and rogue Zambonis.
 
 Procedural Map – Each trek generates a fresh chain of road nodes between Québec and Connecticut.
 

--- a/maple-to-manhattan/eventEngine.js
+++ b/maple-to-manhattan/eventEngine.js
@@ -84,6 +84,46 @@ const baseEvents = [
       },
     ],
   },
+  {
+    id: 'TIM_HORTONS_RUN',
+    title: 'Tim Hortons Pit Stop',
+    description: 'A box of Timbits and a double-double lift everyone\'s spirits.',
+    effects: [
+      { stat: 'morale', delta: 8 },
+      { stat: 'cash', delta: -5 },
+      { stat: 'warmth', delta: 2 },
+    ],
+  },
+  {
+    id: 'ZAMBONI_JAM',
+    title: 'Zamboni Traffic Jam',
+    description: 'A rogue Zamboni creeps along the highway ahead of you.',
+    effects: [
+      { stat: 'fuel', delta: -5 },
+      { stat: 'morale', delta: -3 },
+    ],
+  },
+  {
+    id: 'MAPLE_SYRUP_HEIST',
+    title: 'Maple Syrup Heist',
+    description: 'You stumble onto a shady maple syrup deal in a snowy parking lot.',
+    choices: [
+      {
+        text: 'Buy a jug for $15',
+        effects: [
+          { stat: 'cash', delta: -15 },
+          { inventory: 'gear', delta: 1 },
+          { stat: 'morale', delta: 5 },
+        ],
+      },
+      {
+        text: 'Drive away politely',
+        effects: [
+          { stat: 'morale', delta: -2 },
+        ],
+      },
+    ],
+  },
 ];
 
 function shuffle(arr) {


### PR DESCRIPTION
## Summary
- spice up the event deck with comedic Canadian encounters like a Tim Hortons pit stop, rogue Zamboni, and a maple syrup heist
- note new events in the README

## Testing
- `node --check maple-to-manhattan/eventEngine.js`
- `node --check maple-to-manhattan/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68826f63faa0832084374ff6ca1f263e