### PR TITLE
Add Alberta-themed title and menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Table of Contents
 Overview
 
 Gameplay Features
+#6      Charming micro‑details & menus  ✅ Completed
+#7      Fully-featured Title & Menu Screens  ⏳ In progress
+#8      U.S. “upgrade burst” scene      🚧 Planned
+#9      Greenwich finale & credits      🚧 Planned
+#10     Save / load (localStorage)      🚧 Planned
+#11     Final art & audio drop‑in       🚧 Planned
+#12     Polish, accessibility, QA       🚧 Planned
 
 Screenshots & Art
 
@@ -25,6 +32,7 @@ Credits
 Overview
 Maple Trail drops you into January 1995 with a rust‑speckled station wagon, four kids, and just enough cash to (maybe) cross the border.
 Canada is portrayed as a snow‑blasted, dial‑up‑era wasteland; America is a hyperbolic paradise of fast food and indoor heating. Survive random calamities—moose stampedes, frozen gas pumps, rotary‑phone mishaps—and reach the promised land of Greenwich, CT.
+Journey begins in Alberta.
 
 The project is intentionally zero‑dependency: pure HTML + CSS + vanilla ES‑modules. Open index.html in any modern browser and you’re on the road.
 
@@ -83,24 +91,10 @@ Sprint	Focus	Status
 #3      Procedural map generator        ✅ Completed
 #4      Vehicle breakdown & inventory   ✅ Completed
 #5	Border paperwork mini‑game	✅ Completed
-#6      Charming micro‑details & menus  ⏳ In progress
-#7	U.S. “upgrade burst” scene	🚧 Planned
-#8	Greenwich finale & credits	🚧 Planned
-#9	Save / load (localStorage)	🚧 Planned
-#10	Final art & audio drop‑in	🚧 Planned
-#11	Polish, accessibility, QA	🚧 Planned
-
-All engineering tasks are executed via concise Codex prompts (see /docs/codex_prompts/ for history). Art arrives through the Sora agent pipeline under /assets.
-
-Roadmap
-Core Loop Finish – complete map generation, events, finale.
-
-Balancing Pass – tune stat costs, event probabilities.
-
-Pixel Art Integration – replace every placeholder box with final sprites.
-
-Soundtrack & SFX – cassette mixtape music track, snow crunches, moose bellows.
-
-Accessibility – keyboard navigation, reduced‑motion option.
-
-Release Builds – itch.io ZIP & GitHub Pages demo.
+#6      Charming micro‑details & menus  ✅ Completed
+#7      Fully-featured Title & Menu Screens  ⏳ In progress
+#8      U.S. “upgrade burst” scene      🚧 Planned
+#9      Greenwich finale & credits      🚧 Planned
+#10     Save / load (localStorage)      🚧 Planned
+#11     Final art & audio drop‑in       🚧 Planned
+#12     Polish, accessibility, QA       🚧 Planned

--- a/maple-to-manhattan/assets/manifest.js
+++ b/maple-to-manhattan/assets/manifest.js
@@ -7,9 +7,16 @@ export const sprites = {
     button_instructions: 'assets/button_instructions.png',
     button_options: 'assets/button_options.png',
     button_credits: 'assets/button_credits.png',
+    poutine_volume: 'assets/poutine_volume.png',
     button_resume: 'assets/button_resume.png',
     button_restart: 'assets/button_restart.png',
     button_quit: 'assets/button_quit.png',
+  },
+  bg: {
+    title_mountains: 'assets/title_mountains.png',
+  },
+  npc: {
+    mountie_moose: 'assets/mountie_moose.png',
   },
 };
 

--- a/maple-to-manhattan/creditsScreen.js
+++ b/maple-to-manhattan/creditsScreen.js
@@ -1,0 +1,32 @@
+import { showTitleScreen } from './titleScreen.js';
+import { QUIPS } from './flavor.js';
+
+export function showCredits() {
+  const div = document.createElement('div');
+  div.className = 'menu';
+  div.id = 'creditsScreen';
+  const names = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank', 'Grace', 'Heidi', 'Ivan', 'Judy'];
+  let inner = '<div class="credits-crawl">';
+  names.forEach((n, i) => {
+    inner += `<div>${n}</div>`;
+    if ((i + 1) % 5 === 0) {
+      inner += `<div>${QUIPS[Math.floor(Math.random() * QUIPS.length)]}</div>`;
+    }
+  });
+  inner += '</div><button class="menu-btn" id="backBtn">Back</button>';
+  div.innerHTML = inner;
+  document.body.appendChild(div);
+
+  const esc = e => {
+    if (e.key === 'Escape') {
+      cleanup();
+    }
+  };
+  function cleanup() {
+    window.removeEventListener('keydown', esc);
+    div.remove();
+    showTitleScreen();
+  }
+  window.addEventListener('keydown', esc);
+  div.querySelector('#backBtn').addEventListener('click', cleanup);
+}

--- a/maple-to-manhattan/flavor.js
+++ b/maple-to-manhattan/flavor.js
@@ -19,6 +19,16 @@ export const QUIPS = [
   "Frosty air makes your nostrils stick together.",
   "A mysterious smell reminds you of gym class.",
   "Your map is now 70% duct tape.",
+  "Kid finds petrified beaver tail – trade value dubious.",
+  "Local gas station sells antifreeze popsicles.",
+  "You spot a frozen tumbleweed of hockey tape.",
+  "Road sign reads: 'Next Tim Hortons 300km'.",
+  "Truck ahead drops a snowman off the back.",
+  "Engine sputters but politely apologizes.",
+  "A distant loon laughs at your misfortune.",
+  "Kids debate if moose can be pets.",
+  "Ice fog turns headlights into halos.",
+  "You hear rumors of a warm igloo resort nearby.",
 ];
 
 export function randomQuip() {

--- a/maple-to-manhattan/gameOverScreen.js
+++ b/maple-to-manhattan/gameOverScreen.js
@@ -1,0 +1,28 @@
+import { QUIPS } from './flavor.js';
+import { showTitleScreen } from './titleScreen.js';
+
+const epitaphs = [
+  'Ran out of fuel three moose-lengths from salvation.',
+  'Lost to the great white north.',
+  'Too cold to continue the adventure.'
+];
+
+export function showGameOverScreen(stats) {
+  const div = document.createElement('div');
+  div.className = 'menu';
+  div.id = 'gameOverScreen';
+  const ep = epitaphs[Math.floor(Math.random() * epitaphs.length)];
+  div.innerHTML = `
+    <h2>Game Over</h2>
+    <div id="statsSummary">Health ${stats.health} | Morale ${stats.morale} | Warmth ${stats.warmth}</div>
+    <div>${ep}</div>
+    <button class="menu-btn" id="tryAgainBtn">Try Again</button>
+    <button class="menu-btn" id="quitBtn">Quit to Title</button>
+  `;
+  document.body.appendChild(div);
+  div.querySelector('#tryAgainBtn').addEventListener('click', () => location.reload());
+  div.querySelector('#quitBtn').addEventListener('click', () => {
+    div.remove();
+    showTitleScreen();
+  });
+}

--- a/maple-to-manhattan/instructionsScreen.js
+++ b/maple-to-manhattan/instructionsScreen.js
@@ -1,0 +1,20 @@
+import { showTitleScreen } from './titleScreen.js';
+
+export function showInstructions() {
+  const div = document.createElement('div');
+  div.className = 'menu';
+  div.id = 'instructionsScreen';
+  div.innerHTML = `
+    <div style="max-height:200px;overflow-y:auto;text-align:left;margin-bottom:10px;">
+      <p>Alberta weather forecast: winter for the next three months.</p>
+      <p>Warmth bar: not an optional metric.</p>
+      <p>Press Esc to panic-pause and re-attach hubcaps.</p>
+    </div>
+    <button class="menu-btn" id="backBtn">Back</button>
+  `;
+  document.body.appendChild(div);
+  div.querySelector('#backBtn').addEventListener('click', () => {
+    div.remove();
+    showTitleScreen();
+  });
+}

--- a/maple-to-manhattan/main.js
+++ b/maple-to-manhattan/main.js
@@ -3,7 +3,9 @@ import { generateMap, travelTo } from './map.js';
 import { updateHUD, showToast } from './ui.js';
 import { initEvents, drawRandomEvent } from './eventEngine.js';
 import { showModal } from './modal.js';
-import { openMenu, closeMenu } from './menuManager.js';
+import { showTitleScreen } from './titleScreen.js';
+import { togglePauseMenu } from './pauseMenu.js';
+import { showGameOverScreen } from './gameOverScreen.js';
 import { randomQuip } from './flavor.js';
 import { initTooltips } from './tooltip.js';
 import { loadImages, images } from './loader.js';
@@ -29,11 +31,7 @@ function checkGameOver() {
         gameEnded = true;
         travelBtn.disabled = true;
         campBtn.disabled = true;
-        openMenu('gameOver');
-        const sum = document.getElementById('statsSummary');
-        if (sum) {
-            sum.textContent = `Health ${gameState.stats.health} | Morale ${gameState.stats.morale} | Warmth ${gameState.stats.warmth}`;
-        }
+        showGameOverScreen(gameState.stats);
     }
 }
 
@@ -75,7 +73,7 @@ function draw() {
 }
 
 window.addEventListener('load', async () => {
-    openMenu('title');
+    showTitleScreen();
     const canvas = document.getElementById('gameCanvas');
     ctx = canvas.getContext('2d');
     ctx.font = '12px sans-serif';
@@ -183,23 +181,12 @@ window.addEventListener('load', async () => {
 });
 
 document.body.addEventListener('click', e => {
-    if (e.target.id === 'playBtn' || e.target.id === 'resumeBtn') {
-        closeMenu();
-    } else if (e.target.id === 'restartBtn' || e.target.id === 'tryAgainBtn' || e.target.id === 'quitBtn') {
-        location.reload();
-    } else if (e.target.id === 'optionsBtn') {
-        openMenu('options');
-    }
+    // interactions handled within individual screens
 });
 
 window.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
-        const overlay = document.getElementById('menuOverlay');
-        if (overlay && overlay.querySelector('#pauseMenu')) {
-            closeMenu();
-        } else if (!overlay) {
-            openMenu('pause');
-        }
+        togglePauseMenu();
     }
 });
 

--- a/maple-to-manhattan/map.js
+++ b/maple-to-manhattan/map.js
@@ -25,8 +25,8 @@ export function generateMap(seed = 1) {
   }
   // label key locations
   if (nodes.length > 0) {
-    nodes[0].label = 'Qu\u00e9bec City';
-    nodes[0].id = 'START';
+    nodes[0].label = 'Snow-packed Alberta';
+    nodes[0].id = 'AB';
     const mid = Math.floor(nodes.length / 2);
     nodes[mid].label = 'Border Crossing';
     nodes[mid].id = 'BRD';

--- a/maple-to-manhattan/optionsScreen.js
+++ b/maple-to-manhattan/optionsScreen.js
@@ -1,0 +1,49 @@
+import { showTitleScreen } from './titleScreen.js';
+
+function loadSettings() {
+  return {
+    snow: localStorage.getItem('optSnow') === 'true',
+    jokes: localStorage.getItem('optJokes') === 'true',
+    vol: parseInt(localStorage.getItem('optVol') || '50', 10),
+  };
+}
+
+function saveSettings(settings) {
+  localStorage.setItem('optSnow', settings.snow);
+  localStorage.setItem('optJokes', settings.jokes);
+  localStorage.setItem('optVol', settings.vol);
+}
+
+export function showOptions() {
+  const opts = loadSettings();
+  const div = document.createElement('div');
+  div.className = 'menu';
+  div.id = 'optionsScreen';
+  div.innerHTML = `
+    <label><input type="checkbox" id="snowToggle"> Enable 32-bit snowflakes (GPU-heavy)</label><br>
+    <label><input type="checkbox" id="jokeToggle"> Dad Joke Pop-ups</label><br>
+    <label><img src="./assets/poutine_volume.png" width="16" height="16" alt=""> Volume <input type="range" id="volSlider" min="0" max="100"></label><br>
+    <button class="menu-btn" id="backBtn">Back</button>
+  `;
+  document.body.appendChild(div);
+
+  const snow = div.querySelector('#snowToggle');
+  const jokes = div.querySelector('#jokeToggle');
+  const vol = div.querySelector('#volSlider');
+  snow.checked = opts.snow;
+  jokes.checked = opts.jokes;
+  vol.value = opts.vol;
+
+  function update() {
+    saveSettings({ snow: snow.checked, jokes: jokes.checked, vol: vol.value });
+  }
+  snow.addEventListener('change', update);
+  jokes.addEventListener('change', update);
+  vol.addEventListener('input', update);
+
+  div.querySelector('#backBtn').addEventListener('click', () => {
+    update();
+    div.remove();
+    showTitleScreen();
+  });
+}

--- a/maple-to-manhattan/pauseMenu.js
+++ b/maple-to-manhattan/pauseMenu.js
@@ -1,0 +1,22 @@
+let menu;
+
+export function togglePauseMenu() {
+  if (menu) {
+    menu.remove();
+    menu = null;
+    return;
+  }
+  menu = document.createElement('div');
+  menu.className = 'menu';
+  menu.id = 'pauseMenu';
+  menu.innerHTML = `
+    <h2>Time-out to scrape ice off windshield?</h2>
+    <button class="menu-btn" id="resumeBtn">Resume</button>
+    <button class="menu-btn" id="restartBtn">Restart Run</button>
+    <button class="menu-btn" id="quitBtn">Quit to Title</button>
+  `;
+  document.body.appendChild(menu);
+  menu.querySelector('#resumeBtn').addEventListener('click', () => togglePauseMenu());
+  menu.querySelector('#restartBtn').addEventListener('click', () => location.reload());
+  menu.querySelector('#quitBtn').addEventListener('click', () => location.reload());
+}

--- a/maple-to-manhattan/style.css
+++ b/maple-to-manhattan/style.css
@@ -141,3 +141,78 @@ button:hover {
     opacity: 1;
 }
 
+.menu-btn {
+    padding: 8px 16px;
+    border: 4px solid #fff;
+    background: #3fa9f5;
+    color: #fff;
+    cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><text y="14" font-size="16">🍁</text></svg>') 8 8, pointer;
+    font-size: 16px;
+    image-rendering: pixelated;
+}
+.menu-btn:hover {
+    animation: wiggle 0.4s infinite alternate;
+}
+
+@keyframes wiggle {
+    from { transform: rotate(-3deg); }
+    to { transform: rotate(3deg); }
+}
+
+.credits-crawl {
+    display: flex;
+    flex-direction: column;
+    animation: crawl 20s linear infinite;
+}
+
+@keyframes crawl {
+    from { transform: translateY(100%); }
+    to { transform: translateY(-100%); }
+}
+
+.tooltip-canuck {
+    background: #c00;
+    color: #fff;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 10px;
+    position: absolute;
+    pointer-events: none;
+}
+
+.syrup-drop {
+    position: absolute;
+    width: 4px;
+    height: 4px;
+    background: #c60;
+    animation: drop 2s forwards;
+}
+
+@keyframes drop {
+    to { transform: translateY(40px); opacity: 0; }
+}
+
+.moose-ride {
+    position: absolute;
+    bottom: 40px;
+    left: -100px;
+    width: 64px;
+    height: 32px;
+    image-rendering: pixelated;
+    animation: ride 8s linear forwards;
+}
+
+@keyframes ride {
+    to { transform: translateX(100vw); }
+}
+
+.leaf {
+    position: absolute;
+    animation: leafburst 1s forwards;
+}
+
+@keyframes leafburst {
+    from { opacity: 1; transform: translate(0,0) scale(1); }
+    to { opacity: 0; transform: translate(0,-40px) scale(0.5); }
+}
+

--- a/maple-to-manhattan/titleScreen.js
+++ b/maple-to-manhattan/titleScreen.js
@@ -1,0 +1,77 @@
+import { sprites } from './assets/manifest.js';
+import { showInstructions } from './instructionsScreen.js';
+import { showOptions } from './optionsScreen.js';
+import { showCredits } from './creditsScreen.js';
+
+export function showTitleScreen() {
+  const div = document.createElement('div');
+  div.id = 'titleScreen';
+  div.className = 'menu';
+  div.style.backgroundImage = `url('${sprites.bg.title_mountains}')`;
+  div.style.backgroundSize = 'cover';
+  div.style.animation = 'fadein 1s forwards';
+  div.innerHTML = `
+    <img id="titleLogo" src="${sprites.ui.title_logo}" style="width:200px;height:auto;image-rendering:pixelated;" />
+    <div>
+      <button class="menu-btn" id="playBtn">Play</button>
+      <button class="menu-btn" id="instructionsBtn">Instructions</button>
+      <button class="menu-btn" id="optionsBtn">Options</button>
+      <button class="menu-btn" id="creditsBtn">Credits</button>
+    </div>
+  `;
+  document.body.appendChild(div);
+
+  function drip() {
+    const logo = div.querySelector('#titleLogo');
+    if (!logo) return;
+    const rect = logo.getBoundingClientRect();
+    const drop = document.createElement('div');
+    drop.className = 'syrup-drop';
+    drop.style.left = `${rect.left + rect.width / 2}px`;
+    drop.style.top = `${rect.bottom}px`;
+    document.body.appendChild(drop);
+    drop.addEventListener('animationend', () => drop.remove());
+  }
+  setInterval(drip, 4000);
+
+  function spawnMoose() {
+    const img = document.createElement('img');
+    img.src = sprites.npc.mountie_moose;
+    img.className = 'moose-ride';
+    document.body.appendChild(img);
+    img.addEventListener('animationend', () => img.remove());
+  }
+  spawnMoose();
+  setInterval(spawnMoose, 12000);
+
+  div.querySelector('#playBtn').addEventListener('click', () => div.remove());
+  div.querySelector('#instructionsBtn').addEventListener('click', () => {
+    div.remove();
+    showInstructions();
+  });
+  div.querySelector('#optionsBtn').addEventListener('click', () => {
+    div.remove();
+    showOptions();
+  });
+  div.querySelector('#creditsBtn').addEventListener('click', () => {
+    div.remove();
+    showCredits();
+  });
+
+  div.querySelectorAll('.menu-btn').forEach(btn => {
+    btn.addEventListener('click', e => burst(e.clientX, e.clientY));
+  });
+}
+
+function burst(x, y) {
+  for (let i = 0; i < 6; i++) {
+    const leaf = document.createElement('span');
+    leaf.textContent = '🍁';
+    leaf.className = 'leaf';
+    leaf.style.left = `${x}px`;
+    leaf.style.top = `${y}px`;
+    document.body.appendChild(leaf);
+    leaf.addEventListener('animationend', () => leaf.remove());
+  }
+}
+


### PR DESCRIPTION
## Summary
- create animated title screen with moose, syrup drips and menu buttons
- add instructions, options, credits, pause and game over screens
- persist options via `localStorage`
- start map in Alberta and update flavor text with new quips
- style updates for menu buttons, credits crawl and tooltips
- mark sprint progress in README

## Testing
- `node --check maple-to-manhattan/titleScreen.js`
- `node --check maple-to-manhattan/instructionsScreen.js`
- `node --check maple-to-manhattan/optionsScreen.js`
- `node --check maple-to-manhattan/creditsScreen.js`
- `node --check maple-to-manhattan/pauseMenu.js`
- `node --check maple-to-manhattan/gameOverScreen.js`
- `node --check maple-to-manhattan/main.js`

------
https://chatgpt.com/codex/tasks/task_e_688281020f9c8320849399d48c578bbf