### PR TITLE
Refactor for single-source game state

### DIFF
--- a/maple-to-manhattan/eventEngine.js
+++ b/maple-to-manhattan/eventEngine.js
@@ -1,130 +1,119 @@
-// Event deck and drawing logic
-let deck = [];
+import { modifyStat, modifyInventory } from './state.js';
+
+const PLACEHOLDER_IMG = 'assets/event_placeholder.png';
 
 const baseEvents = [
   {
     id: 'BLIZZARD',
     title: 'Sudden White-Out',
     description: 'Visibility drops to zero; the heater groans.',
-    effects: [
-      { stat: 'warmth', delta: -15 },
-      { stat: 'morale', delta: -5 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Press on', action: () => { modifyStat('warmth', -15); modifyStat('morale', -5); } }
+    ]
   },
   {
     id: 'MOOSE_COLLISION',
     title: 'Moose Collision',
     description: 'A moose barrels across the road and clips the wagon.',
-    effects: [
-      { stat: 'health', delta: -10 },
-      { stat: 'fuel', delta: -5 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Ouch', action: () => { modifyStat('health', -10); modifyStat('fuel', -5); } }
+    ]
   },
   {
     id: 'FUEL_FREEZE',
     title: 'Frozen Fuel Line',
     description: 'Fuel thickens like molasses in the cold.',
-    effects: [
-      { stat: 'fuel', delta: -15 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Sigh', action: () => { modifyStat('fuel', -15); } }
+    ]
   },
   {
     id: 'MIXTAPE_BOOST',
     title: 'Mixtape Morale Boost',
     description: 'Your favorite song warms the soul.',
-    effects: [
-      { stat: 'morale', delta: 10 },
-      { stat: 'warmth', delta: 5 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Rock on', action: () => { modifyStat('morale', 10); modifyStat('warmth', 5); } }
+    ]
   },
   {
     id: 'BARTER_TRADE',
     title: 'Barter Trade',
     description: 'You swap supplies with a friendly traveler.',
-    effects: [
-      { stat: 'fuel', delta: 10 },
-      { stat: 'cash', delta: -10 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Trade', action: () => { modifyStat('fuel', 10); modifyStat('cash', -10); } }
+    ]
   },
   {
     id: 'FEE_REFUND',
     title: 'Border Fee Refund',
     description: 'Turns out you overpaid the last toll.',
-    effects: [
-      { stat: 'cash', delta: 20 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Lucky break', action: () => { modifyStat('cash', 20); } }
+    ]
   },
   {
     id: 'GAS_STATION_CACHE',
     title: 'Abandoned Gas Station',
     description: 'You find a dusty box of spare parts.',
-    effects: [
-      { inventory: 'parts', delta: 1 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Take them', action: () => { modifyInventory('parts', 1); } }
+    ]
   },
   {
     id: 'FLAT_TIRE',
     title: 'Flat Tire',
     description: 'A sharp rock blows out a tire.',
+    image: PLACEHOLDER_IMG,
     choices: [
       {
         text: 'Use spare part to repair',
         requires: { inventory: 'parts', count: 1 },
-        effects: [
-          { inventory: 'parts', delta: -1 },
-          { stat: 'morale', delta: 3 },
-        ],
+        action: () => { modifyInventory('parts', -1); modifyStat('morale', 3); }
       },
       {
         text: 'Drive on the rim',
-        effects: [
-          { stat: 'health', delta: -10 },
-          { stat: 'fuel', delta: -5 },
-        ],
-      },
-    ],
+        action: () => { modifyStat('health', -10); modifyStat('fuel', -5); }
+      }
+    ]
   },
   {
     id: 'TIM_HORTONS_RUN',
     title: 'Tim Hortons Pit Stop',
     description: 'A box of Timbits and a double-double lift everyone\'s spirits.',
-    effects: [
-      { stat: 'morale', delta: 8 },
-      { stat: 'cash', delta: -5 },
-      { stat: 'warmth', delta: 2 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Yum', action: () => { modifyStat('morale', 8); modifyStat('cash', -5); modifyStat('warmth', 2); } }
+    ]
   },
   {
     id: 'ZAMBONI_JAM',
     title: 'Zamboni Traffic Jam',
     description: 'A rogue Zamboni creeps along the highway ahead of you.',
-    effects: [
-      { stat: 'fuel', delta: -5 },
-      { stat: 'morale', delta: -3 },
-    ],
+    image: PLACEHOLDER_IMG,
+    choices: [
+      { text: 'Wait it out', action: () => { modifyStat('fuel', -5); modifyStat('morale', -3); } }
+    ]
   },
   {
     id: 'MAPLE_SYRUP_HEIST',
     title: 'Maple Syrup Heist',
     description: 'You stumble onto a shady maple syrup deal in a snowy parking lot.',
+    image: PLACEHOLDER_IMG,
     choices: [
-      {
-        text: 'Buy a jug for $15',
-        effects: [
-          { stat: 'cash', delta: -15 },
-          { inventory: 'gear', delta: 1 },
-          { stat: 'morale', delta: 5 },
-        ],
-      },
-      {
-        text: 'Drive away politely',
-        effects: [
-          { stat: 'morale', delta: -2 },
-        ],
-      },
-    ],
-  },
+      { text: 'Buy a jug for $15', action: () => { modifyStat('cash', -15); modifyInventory('gear', 1); modifyStat('morale', 5); } },
+      { text: 'Drive away politely', action: () => { modifyStat('morale', -2); } }
+    ]
+  }
 ];
+
+let deck = [];
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {

--- a/maple-to-manhattan/map.js
+++ b/maple-to-manhattan/map.js
@@ -1,5 +1,5 @@
 import { gameState } from './state.js';
-import { updateHUD } from './ui.js';
+import { updateUI } from './ui.js';
 
 function mulberry32(a) {
   return function () {
@@ -54,7 +54,7 @@ export function travelTo(nodes, targetIndex, wagonPos, onArrival) {
       requestAnimationFrame(animate);
     } else {
       gameState.nodeIndex = targetIndex;
-      updateHUD();
+      updateUI();
       if (onArrival) onArrival(targetIndex);
     }
   }

--- a/maple-to-manhattan/modal.js
+++ b/maple-to-manhattan/modal.js
@@ -20,20 +20,18 @@ const icons = {
 };
 
 export function showModal(ev, onChoice) {
-  if (ev.choices) {
-    modal.innerHTML = `<div class="modal">
+  const choicesHtml = ev.choices
+    .map((c, i) => `<button data-idx="${i}" id="choice${i}">${c.text}</button>`)
+    .join('');
+  modal.innerHTML = `<div class="modal">
+      ${ev.image ? `<img src="${ev.image}" class="event-img" />` : ''}
       <h3>${ev.title}</h3>
       <p>${ev.description}</p>
-      <div class="choices">
-        ${ev.choices
-          .map(
-            (c, i) =>
-              `<button data-idx="${i}" id="choice${i}">${c.text}</button>`
-          )
-          .join('')}
-      </div>
+      <div class="choices">${choicesHtml || '<button id="modalOk">OK</button>'}</div>
     </div>`;
-    modal.classList.remove('hidden');
+  modal.classList.remove('hidden');
+
+  if (ev.choices && ev.choices.length) {
     ev.choices.forEach((c, i) => {
       const btn = document.getElementById(`choice${i}`);
       if (c.requires && c.requires.inventory) {
@@ -47,6 +45,7 @@ export function showModal(ev, onChoice) {
         'click',
         () => {
           hideModal();
+          if (typeof c.action === 'function') c.action();
           if (onChoice) onChoice(c);
           window.dispatchEvent(new Event('modalClosed'));
         },
@@ -54,21 +53,6 @@ export function showModal(ev, onChoice) {
       );
     });
   } else {
-    modal.innerHTML = `<div class="modal">
-      <h3>${ev.title}</h3>
-      <p>${ev.description}</p>
-      <ul>
-        ${ev.effects
-          .map(
-            e => `<li>${icons[e.stat || e.inventory] || ''} ${
-            e.stat || e.inventory
-          }: ${e.delta > 0 ? '+' : ''}${e.delta}</li>`
-          )
-          .join('')}
-      </ul>
-      <button id="modalOk">OK</button>
-    </div>`;
-    modal.classList.remove('hidden');
     document.getElementById('modalOk').addEventListener(
       'click',
       () => {

--- a/maple-to-manhattan/state.js
+++ b/maple-to-manhattan/state.js
@@ -14,6 +14,13 @@ export const gameState = {
     gear: 0,
     form_duplicate_carbon: 1,
   },
+  wagonPos: { x: 0, y: 0 },
+  nodes: [],
+  gameEnded: false,
+  ui: {
+    travelDisabled: false,
+    campDisabled: false,
+  },
 };
 
 export function clampStat(key) {
@@ -34,6 +41,13 @@ export function modifyInventory(item, delta) {
     window.dispatchEvent(
       new CustomEvent('inventoryChanged', { detail: { item } })
     );
+  }
+}
+
+export function setUIDisabled(key, val) {
+  if (gameState.ui.hasOwnProperty(key)) {
+    gameState.ui[key] = val;
+    window.dispatchEvent(new Event('uiChanged'));
   }
 }
 

--- a/maple-to-manhattan/ui.js
+++ b/maple-to-manhattan/ui.js
@@ -1,7 +1,7 @@
 import { gameState } from './state.js';
 import { sprites } from './assets/manifest.js';
 
-export function updateHUD() {
+export function updateUI() {
   ['health', 'morale', 'warmth', 'fuel'].forEach(stat => {
     const span = document.querySelector(`#${stat} .bar span`);
     if (span) span.style.width = `${gameState.stats[stat]}%`;
@@ -29,6 +29,11 @@ export function updateHUD() {
     }
     if (span) span.textContent = gameState.inventory[item];
   });
+
+  const travelBtn = document.getElementById('travelBtn');
+  const campBtn = document.getElementById('campBtn');
+  if (travelBtn) travelBtn.disabled = gameState.ui.travelDisabled;
+  if (campBtn) campBtn.disabled = gameState.ui.campDisabled;
 }
 
 window.addEventListener('statChanged', e => {


### PR DESCRIPTION
## Summary
- centralize gameplay data in `gameState`
- create `updateUI` for all rendering duties
- drive random events from data with actions that mutate `gameState`
- separate travel and camp logic from UI manipulation

## Testing
- `node --check maple-to-manhattan/main.js`
- `node --check maple-to-manhattan/eventEngine.js`
- `node --check maple-to-manhattan/modal.js`
- `node --check maple-to-manhattan/map.js`
- `node --check maple-to-manhattan/ui.js`
- `node --check maple-to-manhattan/state.js`


------
https://chatgpt.com/codex/tasks/task_e_688284ed56bc83209c89314fc7719d60